### PR TITLE
Feature implementation from commits 0ac05da..8058b78

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+github: mkdocs

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -27,6 +27,241 @@ The current and past members of the MkDocs team.
 * [@oprypin](https://github.com/oprypin/)
 * [@ultrabug](https://github.com/ultrabug/)
 
+## Version 1.6.0 (2024-04-20)
+
+### Local preview
+
+*   `mkdocs serve` no longer locks up the browser when more than 5 tabs are open. This is achieved by closing the polling connection whenever a tab becomes inactive. Background tabs will no longer auto-reload either - that will instead happen as soon the tab is opened again. Context: #3391
+
+*   New flag `serve --open` to open the site in a browser.  
+    After the first build is finished, this flag will cause the default OS Web browser to be opened at the home page of the local site.  
+    Context: #3500
+
+#### Drafts
+
+> DANGER: **Changed from version 1.5.**
+
+**The `exclude_docs` config was split up into two separate concepts.**
+
+The `exclude_docs` config no longer has any special behavior for `mkdocs serve` - it now always completely excludes the listed documents from the site.
+
+If you wish to use the "drafts" functionality like the `exclude_docs` key used to do in MkDocs 1.5, please switch to the **new config key `draft_docs`**.
+
+See [documentation](../user-guide/configuration.md#exclude_docs).
+
+Other changes:
+
+* Reduce warning levels when a "draft" page has a link to a non-existent file. Context: #3449
+
+### Update to deduction of page titles
+
+MkDocs 1.5 had a change in behavior in deducing the page titles from the first heading. Unfortunately this could cause unescaped HTML tags or entities to appear in edge cases.
+
+Now tags are always fully sanitized from the title. Though it still remains the case that [`Page.title`][mkdocs.structure.pages.Page.title] is expected to contain HTML entities and is passed directly to the themes.
+
+Images (notably, emojis in some extensions) get preserved in the title only through their `alt` attribute's value.
+
+Context: #3564, #3578
+
+### Themes
+
+* Built-in themes now also support Polish language (#3613)
+
+#### "readthedocs" theme
+
+*   Fix: "readthedocs" theme can now correctly handle deeply nested nav configurations (over 2 levels deep), without confusedly expanding all sections and jumping around vertically. (#3464)
+
+*   Fix: "readthedocs" theme now shows a link to the repository (with a generic logo) even when isn't one of the 3 known hosters. (#3435)
+
+*   "readthedocs" theme now also has translation for the word "theme" in the footer that mistakenly always remained in English. (#3613, #3625)
+
+#### "mkdocs" theme
+
+The "mkdocs" theme got a big update to a newer version of Bootstrap, meaning a slight overhaul of styles. Colors (most notably of admonitions) have much better contrast.
+
+The "mkdocs" theme now has support for dark mode - both automatic (based on the OS/browser setting) and with a manual toggle. Both of these options are **not** enabled by default and need to be configured explicitly.  
+See `color_mode`, `user_color_mode_toggle` in [**documentation**](../user-guide/choosing-your-theme.md#mkdocs).
+
+> WARNING: **Possible breaking change.**
+>
+> jQuery is no longer included into the "mkdocs" theme. If you were relying on it in your scripts, you will need to separately add it first (into mkdocs.yml) as an extra script:
+>
+> ```yaml
+> extra_javascript:
+>   - https://code.jquery.com/jquery-3.7.1.min.js
+> ```
+>
+> Or even better if the script file is copied and included from your docs dir.
+
+Context: #3493, #3649
+
+### Configuration
+
+#### New "`enabled`" setting for all plugins
+
+You may have seen some plugins take up the convention of having a setting `enabled: false` (or usually controlled through an environment variable) to make the plugin do nothing.
+
+Now *every* plugin has this setting. Plugins can still *choose* to implement this config themselves and decide how it behaves (and unless they drop older versions of MkDocs, they still should for now), but now there's always a fallback for every plugin.
+
+See [**documentation**](../user-guide/configuration.md/#enabled-option). Context: #3395
+
+### Validation
+
+#### Validation of hyperlinks between pages
+
+##### Absolute links
+
+> Historically, within Markdown, MkDocs only recognized **relative** links that lead to another physical `*.md` document (or media file). This is a good convention to follow because then the source pages are also freely browsable without MkDocs, for example on GitHub. Whereas absolute links were left unmodified (making them often not work as expected or, more recently, warned against).
+
+If you dislike having to always use relative links, now you can opt into absolute links and have them work correctly.
+
+If you set the setting `validation.links.absolute_links` to the new value `relative_to_docs`, all Markdown links starting with `/` will be understood as being relative to the `docs_dir` root. The links will then be validated for correctness according to all the other rules that were already working for relative links in prior versions of MkDocs. For the HTML output, these links will still be turned relative so that the site still works reliably.
+
+So, now any document (e.g. "dir1/foo.md") can link to the document "dir2/bar.md" as `[link](/dir2/bar.md)`, in addition to the previously only correct way `[link](../dir2/bar.md)`.
+
+You have to enable the setting, though. The default is still to just skip any processing of such links.
+
+See [**documentation**](../user-guide/configuration.md#validation-of-absolute-links). Context: #3485
+
+###### Absolute links within nav
+
+Absolute links within the `nav:` config were also always skipped. It is now possible to also validate them in the same way with `validation.nav.absolute_links`. Though it makes a bit less sense because then the syntax is simply redundant with the syntax that comes without the leading slash.
+
+##### Anchors
+
+There is a new config setting that is recommended to enable warnings for:
+
+```yaml
+validation:
+  anchors: warn
+```
+
+Example of a warning that this can produce:
+
+```text
+WARNING -  Doc file 'foo/example.md' contains a link '../bar.md#some-heading', but the doc 'foo/bar.md' does not contain an anchor '#some-heading'.
+```
+
+Any of the below methods of declaring an anchor will be detected by MkDocs:
+
+```markdown
+## Heading producing an anchor
+
+## Another heading {#custom-anchor-for-heading-using-attr-list}
+
+<a id="raw-anchor"></a>
+
+[](){#markdown-anchor-using-attr-list}
+```
+
+Plugins and extensions that insert anchors, in order to be compatible with this, need to be developed as treeprocessors that insert `etree` elements as their mode of operation, rather than raw HTML which is undetectable for this purpose.
+
+If you as a user are dealing with falsely reported missing anchors and there's no way to resolve this, you can choose to disable these messages by setting this option to `ignore` (and they are at INFO level by default anyway).
+
+See [**documentation**](../user-guide/configuration.md#validation). Context: #3463
+
+Other changes:
+
+*   When the `nav` config is not specified at all, the `not_in_nav` setting (originally added in 1.5.0) gains an additional behavior: documents covered by `not_in_nav` will not be part of the automatically deduced navigation. Context: #3443
+
+*   Fix: the `!relative` YAML tag for `markdown_extensions` (originally added in 1.5.0) - it was broken in many typical use cases.
+
+    See [**documentation**](../user-guide/configuration.md#paths-relative-to-the-current-file-or-site). Context: #3466
+
+*   Config validation now exits on first error, to avoid showing bizarre secondary errors. Context: #3437
+
+*   MkDocs used to shorten error messages for unexpected errors such as "file not found", but that is no longer the case, the full error message and stack trace will be possible to see (unless the error has a proper handler, of course). Context: #3445
+
+### Upgrades for plugin developers
+
+#### Plugins can add multiple handlers for the same event type, at multiple priorities
+
+See [`mkdocs.plugins.CombinedEvent`][] in [**documentation**](../dev-guide/plugins.md#event-priorities). Context: #3448
+
+#### Enabling true generated files and expanding the [`File`][mkdocs.structure.files.File] API
+
+See [**documentation**][mkdocs.structure.files.File].
+
+*   There is a new pair of attributes [`File.content_string`][mkdocs.structure.files.File.content_string]/[`content_bytes`][mkdocs.structure.files.File.content_bytes] that becomes the official API for obtaining the content of a file and is used by MkDocs itself.
+
+    This replaces the old approach where one had to manually read the file located at [`File.abs_src_path`][mkdocs.structure.files.File.abs_src_path], although that is still the primary action that these new attributes do under the hood.
+
+*   The content of a `File` can be backed by a string and no longer has to be a real existing file at `abs_src_path`.
+
+    It is possible to **set** the attribute `File.content_string` or `File.content_bytes` and it will take precedence over `abs_src_path`.
+
+    Further, `abs_src_path` is no longer guaranteed to be present and can be `None` instead. MkDocs itself still uses physical files in all cases, but eventually plugins will appear that don't populate this attribute.
+
+*   There is a new constructor [`File.generated()`][mkdocs.structure.files.File.generated] that should be used by plugins instead of the `File()` constructor. It is much more convenient because one doesn't need to manually look up the values such as `docs_dir` and `use_directory_urls`. Its signature is one of:
+
+    ```python
+    f = File.generated(config: MkDocsConfig, src_uri: str, content: str | bytes)
+    f = File.generated(config: MkDocsConfig, src_uri: str, abs_src_path: str)
+    ```
+
+    This way, it is now extremely easy to add a virtual file even from a hook:
+
+    ```python
+    def on_files(files: Files, config: MkDocsConfig):
+        files.append(File.generated(config, 'fake/path.md', content="Hello, world!"))
+    ```
+
+    For large content it is still best to use physical files, but one no longer needs to manipulate the path by providing a fake unused `docs_dir`.
+
+*   There is a new attribute [`File.generated_by`][mkdocs.structure.files.File.generated_by] that arose by convention - for generated files it should be set to the name of the plugin (the key in the `plugins:` collection) that produced this file. This attribute is populated automatically when using the `File.generated()` constructor.
+
+*   It is possible to set the [`edit_uri`][mkdocs.structure.files.File.edit_uri] attribute of a `File`, for example from a plugin or hook, to make it different from the default (equal to `src_uri`), and this will be reflected in the edit link of the document. This can be useful because some pages aren't backed by a real file and are instead created dynamically from some other source file or script. So a hook could set the `edit_uri` to that source file or script accordingly.
+
+*   The `File` object now stores its original `src_dir`, `dest_dir`, `use_directory_urls` values as attributes.
+
+*   Fields of `File` are computed on demand but cached. Only the three above attributes are primary ones, and partly also [`dest_uri`][mkdocs.structure.files.File.dest_uri]. This way, it is possible to, for example, overwrite `dest_uri` of a `File`, and `abs_dest_path` will be calculated based on it. However you need to clear the attribute first using `del f.abs_dest_path`, because the values are cached.
+
+*   `File` instances are now hashable (can be used as keys of a `dict`). Two files can no longer be considered "equal" unless it's the exact same instance of `File`.
+
+Other changes:
+
+*   The internal storage of `File` objects inside a `Files` object has been reworked, so any plugins that choose to access `Files._files` will get a deprecation warning.
+
+*   The order of `File` objects inside a `Files` collection is no longer significant when automatically inferring the `nav`. They get forcibly sorted according to the default alphabetic order.
+
+Context: #3451, #3463
+
+### Hooks and debugging
+
+*   Hook files can now import adjacent *.py files using the `import` statement. Previously this was possible to achieve only through a `sys.path` workaround. See the new mention in [documentation](../user-guide/configuration.md#hooks). Context: #3568
+
+*   Verbose `-v` log shows the sequence of plugin events in more detail - shows each invoked plugin one by one, not only the event type. Context: #3444
+
+### Deprecations
+
+*   Python 3.7 is no longer supported, Python 3.12 is officially supported. Context: #3429
+
+*   The theme config file `mkdocs_theme.yml` no longer executes YAML tags. Context: #3465
+
+*   The plugin event `on_page_read_source` is soft-deprecated because there is always a better alternative to it (see the new `File` API or just `on_page_markdown`, depending on the desired interaction).
+
+    When multiple plugins/hooks apply this event handler, they trample over each other, so now there is a warning in that case.
+
+    See [**documentation**](../dev-guide/plugins.md#on_page_read_source). Context: #3503
+
+#### API deprecations
+
+*   It is no longer allowed to set `File.page` to a type other than `Page` or a subclass thereof. Context: #3443 - following the deprecation in version 1.5.3 and #3381.
+
+*   `Theme._vars` is deprecated - use `theme['foo']` instead of `theme._vars['foo']`
+
+*   `utils`: `modified_time()`, `get_html_path()`, `get_url_path()`, `is_html_file()`, `is_template_file()` are removed. `path_to_url()` is deprecated.
+
+*   `LiveReloadServer.watch()` no longer accepts a custom callback.
+
+Context: #3429
+
+### Misc
+
+* The `sitemap.xml.gz` file is slightly more reproducible and no longer changes on every build, but instead only once per day (upon a date change). Context: #3460
+
+Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.5.3...1.6.0).
+
 ## Version 1.5.3 (2023-09-18)
 
 *   Fix `mkdocs serve` sometimes locking up all browser tabs when navigating quickly (#3390)

--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -431,11 +431,13 @@ Since MkDocs 1.4, plugins can choose to set a priority value for their events. E
 
 #### ::: mkdocs.plugins.event_priority
 
-There may also arise a need to register a handler for the same event at multiple different priorities.
-
-`CombinedEvent` makes this possible since MkDocs 1.6.
-
-#### ::: mkdocs.plugins.CombinedEvent
+> NEW: **New in version 1.6**
+>
+> There may also arise a need to register a handler for the same event at multiple different priorities.
+>
+> `CombinedEvent` makes this possible.
+>
+> #### ::: mkdocs.plugins.CombinedEvent
 
 ### Handling Errors
 
@@ -504,7 +506,7 @@ To ensure that your plugins' log messages adhere with MkDocs' formatting and `--
 `log.error()` is another logging level that is differentiated by its look, but in all other ways it functions the same as `warning`, so it's strange to use it. If your plugin encounters an actual error, it is best to just interrupt the build by raising [`mkdocs.exceptions.PluginError`][] (which will also log an ERROR message).
 
 <!-- -->
-> NEW: New in MkDocs 1.5
+> NEW: **New in version 1.5**
 >
 > MkDocs now provides a `get_plugin_logger()` convenience function that returns a logger like the above that is also prefixed with the plugin's name.
 >

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -4,7 +4,7 @@ Building Documentation with MkDocs
 
 ---
 
-The MkDocs Developer Guide provides documentation for users of MkDocs. See
+The MkDocs User Guide provides documentation for users of MkDocs. See
 [Getting Started] for an introductory tutorial. You can jump directly to a
 page listed below, or use the *next* and *previous* buttons in the navigation
 bar at the top of the page to move through the documentation in order.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -661,25 +661,40 @@ option every time the `mkdocs serve` command is called.
 
 ### use_directory_urls
 
-This setting controls the style used for linking to pages within the
-documentation.
+This setting controls the directory structure of the generated documentation, and thereby the URL format used for linking to pages.
 
-The following table demonstrates how the URLs used on the site differ when
+The following tables demonstrate how the directory structure and URLs used on the site differ when
 setting `use_directory_urls` to `true` or `false`.
 
-Source file      | use_directory_urls: true  | use_directory_urls: false
----------------- | ------------------------- | -------------------------
-index.md         | /                         | /index.html
-api-guide.md     | /api-guide/               | /api-guide.html
-about/license.md | /about/license/           | /about/license.html
+**`use_directory_urls: false`**
+
+This setting is needed when the documentation is hosted on systems that can't
+access the file `X/index.html` when given the URL `X`. When set to `false`,
+no additional `X` directory is created, and the file is simply stored as `X.html`.
+Links are created that point directly to the target *file* rather than a target
+*directory*.
+
+Source file      | Generated File     | URL Format
+---------------- | ------------------ | -------------------
+index.md         | index.html         | /index.html
+api-guide.md     | api-guide.html     | /api-guide.html
+about/license.md | about/license.html | /about/license.html
+
+For example, this needs to be set to `false` when:
+
+* opening pages directly from the file system
+* publishing the documentation to a static S3 website.
+
+**`use_directory_urls: true`**
 
 The default style of `use_directory_urls: true` creates more user friendly URLs,
 and is usually what you'll want to use.
 
-The alternate style can be useful if you want your documentation to remain
-properly linked when opening pages directly from the file system, because it
-creates links that point directly to the target *file* rather than the target
-*directory*.
+Source file      | Generated File            | URL Format
+---------------- | ------------------------- | --------------
+index.md         | /index.html               | /
+api-guide.md     | /api-guide/index.html     | /api-guide/
+about/license.md | /about/license/index.html | /about/license
 
 **default**: `true`
 

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -8,8 +8,8 @@ A basic guide to deploying your docs to various hosting providers
 
 If you host the source code for a project on [GitHub], you can easily use
 [GitHub Pages] to host the documentation for your project. There are two basic
-types of GitHub Pages sites: [Project Pages] sites, and [User and Organization
-Pages] sites. They are nearly identical but have some important differences,
+[types of GitHub Pages sites]: Project Pages sites, and User and Organization
+Pages sites. They are nearly identical but have some important differences,
 which require a different work flow when deploying.
 
 ### Project Pages
@@ -95,8 +95,7 @@ documentation on [Troubleshooting custom domains].
 
 [GitHub]: https://github.com/
 [GitHub Pages]: https://pages.github.com/
-[Project Pages]: https://help.github.com/articles/user-organization-and-project-pages/#project-pages-sites
-[User and Organization Pages]: https://help.github.com/articles/user-organization-and-project-pages/#user-and-organization-pages-sites
+[types of GitHub Pages sites]: https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites
 [ghp-import]: https://github.com/davisp/ghp-import
 [remote_branch]: ./configuration.md#remote_branch
 [Custom Domain]: https://help.github.com/articles/adding-or-removing-a-custom-domain-for-your-github-pages-site

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -107,23 +107,14 @@ documentation on [Troubleshooting custom domains].
 ## Read the Docs
 
 [Read the Docs][rtd] offers free documentation hosting. You can import your docs
-using any major version control system, including Mercurial, Git, Subversion,
-and Bazaar. Read the Docs supports MkDocs out-of-the-box. Follow the
-[instructions] on their site to arrange the files in your repository properly,
+using the Git version control system. Read the Docs supports MkDocs out-of-the-box.
+Follow the [instructions] on their site to arrange the files in your repository properly,
 create an account and point it at your publicly hosted repository. If properly
 configured, your documentation will update each time you push commits to your
 public repository.
 
-NOTE:
-To benefit from all of the [features] offered by Read the Docs, you will need
-to use the [Read the Docs theme][theme] which ships with MkDocs. The various
-themes which may be referenced in Read the Docs' documentation are Sphinx
-specific themes and will not work with MkDocs.
-
 [rtd]: https://readthedocs.org/
 [instructions]: https://docs.readthedocs.io/en/stable/intro/getting-started-with-mkdocs.html
-[features]: https://docs.readthedocs.io/en/latest/features.html
-[theme]: ./choosing-your-theme.md#readthedocs
 
 ## Other Providers
 

--- a/mkdocs/__init__.py
+++ b/mkdocs/__init__.py
@@ -2,4 +2,4 @@
 
 
 # For acceptable version formats, see https://www.python.org/dev/peps/pep-0440/
-__version__ = '1.5.3'
+__version__ = '1.6.0'

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -1,4 +1,5 @@
 """Implements the plugin API for MkDocs."""
+
 from __future__ import annotations
 
 import logging
@@ -323,7 +324,10 @@ class BasePlugin(Generic[SomeConfig]):
 
     def on_page_read_source(self, /, *, page: Page, config: MkDocsConfig) -> str | None:
         """
-        Deprecated: Since MkDocs 1.6, instead set `content_bytes`/`content_string` of a `File`.
+        > DEPRECATED: Instead of this event, prefer one of these alternatives:
+        >
+        > * Since MkDocs 1.6, instead set `content_bytes`/`content_string` of a `File` inside [`on_files`][].
+        > * Usually (although it's not an exact alternative), `on_page_markdown` can serve the same purpose.
 
         The `on_page_read_source` event can replace the default mechanism to read
         the contents of a page's source from the filesystem.

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -354,6 +354,12 @@ class File:
 
     @utils.weak_property
     def edit_uri(self) -> str | None:
+        """
+        A path relative to the source repository to use for the "edit" button.
+
+        Defaults to `src_uri` and can be overwritten.
+        For generated files this should be set to `None`.
+        """
         return self.src_uri if self.generated_by is None else None
 
     def _get_stem(self) -> str:

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -231,7 +231,8 @@ class Page(StructureItem):
 
         Before calling `read_source()`, this value is empty. It can also be updated by `render()`.
 
-        Check these in order and use the first that returns a valid title:
+        Checks these in order and uses the first that returns a valid title:
+
         - value provided on init (passed in from config)
         - value of metadata 'title'
         - content of the first H1 in Markdown content

--- a/mkdocs/templates/sitemap.xml
+++ b/mkdocs/templates/sitemap.xml
@@ -5,7 +5,6 @@
     <url>
          <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
          {% if file.page.update_date %}<lastmod>{{file.page.update_date}}</lastmod>{% endif %}
-         <changefreq>daily</changefreq>
     </url>
     {%- endif -%}
 {% endfor %}

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1594,7 +1594,8 @@ class NestedSubConfigTest(TestCase):
         validation = c.PropagatingSubConfig[defaults.MkDocsConfig.Validation]()
 
     def test_unspecified(self) -> None:
-        for cfg in {}, {'validation': {}}:
+        cfgs: list[dict] = [{}, {'validation': {}}]
+        for cfg in cfgs:
             with self.subTest(cfg):
                 conf = self.get_config(
                     self.Schema,

--- a/mkdocs/tests/theme_tests.py
+++ b/mkdocs/tests/theme_tests.py
@@ -104,3 +104,22 @@ class ThemeTests(unittest.TestCase):
                 ],
             )
             self.assertEqual(theme.static_templates, {'sitemap.xml', 'child.html', 'parent.html'})
+
+    def test_empty_config_file(self):
+        # Test for themes with *empty* mkdocs_theme.yml.
+        # See https://github.com/mkdocs/mkdocs/issues/3699
+        m = mock.Mock(
+            # yaml.load returns "None" for an empty file
+            side_effect=[None]
+        )
+        with mock.patch('yaml.load', m) as m:
+            theme = Theme(name='mkdocs')
+            # Should only have the default name and locale __vars set in
+            # Theme.__init__()
+            self.assertEqual(
+                dict(theme),
+                {
+                    'name': 'mkdocs',
+                    'locale': parse_locale('en'),
+                },
+            )

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -138,6 +138,9 @@ class Theme(MutableMapping[str, Any]):
                 f"Please upgrade to a current version of the theme."
             )
 
+        if theme_config is None:
+            theme_config = {}
+
         log.debug(f"Loaded theme configuration for '{name}' from '{file_path}': {theme_config}")
 
         if parent_theme := theme_config.pop('extends', None):

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -156,11 +156,11 @@
                             <li class="nav-item">
                                 <a href="{{ config.repo_url }}" class="nav-link">
                                     {%- if config.repo_name == 'GitHub' -%}
-                                        <i class="fa fa-github"></i> {{ config.repo_name }}
+                                        <i class="fa-brands fa-github"></i> {{ config.repo_name }}
                                     {%- elif config.repo_name == 'Bitbucket' -%}
-                                        <i class="fa fa-bitbucket"></i> {{ config.repo_name }}
+                                        <i class="fa-brands fa-bitbucket"></i> {{ config.repo_name }}
                                     {%- elif config.repo_name == 'GitLab' -%}
-                                        <i class="fa fa-gitlab"></i> {{ config.repo_name }}
+                                        <i class="fa-brands fa-gitlab"></i> {{ config.repo_name }}
                                     {%- else -%}
                                     {{ config.repo_name }}
                                     {%- endif -%}

--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -139,8 +139,9 @@ document.addEventListener("DOMContentLoaded", function () {
         menu.parentElement.addEventListener('hide.bs.dropdown', function() {
             menu.scrollTop = 0;
             var dropdown = menu.querySelector('.dropdown-submenu > a');
-            if (dropdown)
-              dropdown.classList.remove('open');
+            if (dropdown) {
+                dropdown.classList.remove('open');
+            }
             menu.querySelectorAll('.dropdown-menu .dropdown-menu').forEach(function(submenu) {
                 submenu.classList.remove('show');
             });

--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -138,7 +138,9 @@ document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll('.dropdown-menu').forEach(function(menu) {
         menu.parentElement.addEventListener('hide.bs.dropdown', function() {
             menu.scrollTop = 0;
-            menu.querySelector('.dropdown-submenu > a').classList.remove('open');
+            const dropdown = menu.querySelector('.dropdown-submenu > a')
+            if (dropdown)
+              dropdown.classList.remove('open');
             menu.querySelectorAll('.dropdown-menu .dropdown-menu').forEach(function(submenu) {
                 submenu.classList.remove('show');
             });

--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -91,7 +91,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
       // First, close any sibling dropdowns.
       var container = item.parentElement.parentElement;
-      container.querySelectorAll('> .dropdown-submenu > a').forEach(function(el) {
+      container.querySelectorAll(':scope > .dropdown-submenu > a').forEach(function(el) {
           if (el !== item) {
               hideInnerDropdown(el);
           }

--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -138,7 +138,7 @@ document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll('.dropdown-menu').forEach(function(menu) {
         menu.parentElement.addEventListener('hide.bs.dropdown', function() {
             menu.scrollTop = 0;
-            const dropdown = menu.querySelector('.dropdown-submenu > a')
+            var dropdown = menu.querySelector('.dropdown-submenu > a');
             if (dropdown)
               dropdown.classList.remove('open');
             menu.querySelectorAll('.dropdown-menu .dropdown-menu').forEach(function(submenu) {

--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -57,10 +57,10 @@ document.addEventListener("DOMContentLoaded", function () {
       var page;
       switch (key) {
           case shortcuts.next:
-              page = document.querySelector('.navbar a[rel="next"]:first').getAttribute('href');
+              page = document.querySelector('.navbar a[rel="next"]');
               break;
           case shortcuts.previous:
-              page = document.querySelector('.navbar a[rel="prev"]:first').getAttribute('href');
+              page = document.querySelector('.navbar a[rel="prev"]');
               break;
           case shortcuts.search:
               e.preventDefault();
@@ -74,9 +74,9 @@ document.addEventListener("DOMContentLoaded", function () {
               break;
           default: break;
       }
-      if (page) {
+      if (page && page.hasAttribute('href')) {
           keyboard_modal.hide();
-          window.location.href = page;
+          window.location.href = page.getAttribute('href');
       }
     });
 

--- a/mkdocs/themes/mkdocs/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/zh_CN/LC_MESSAGES/messages.po
@@ -7,15 +7,16 @@ msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
-"PO-Revision-Date: 2022-08-23 04:28+0800\n"
+"PO-Revision-Date: 2024-04-26 06:34+0800\n"
 "Last-Translator: xingkong0113 <dingpengyu06@gmail.com>\n"
-"Language: zh_CN\n"
 "Language-Team: zh_Hans_CN <dingpengyu06@gmail.com>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.14.0\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: mkdocs/themes/mkdocs/404.html:8
 msgid "Page not found"
@@ -81,7 +82,7 @@ msgstr "上一页面"
 
 #: mkdocs/themes/mkdocs/search-modal.html:9
 msgid "From here you can search these documents. Enter your search terms below."
-msgstr "从这里你可以搜索这些文件。在下面输入您的搜索内容。"
+msgstr "从这里您可以搜索这些文档。在下面输入您需要搜索的内容。"
 
 #: mkdocs/themes/mkdocs/search-modal.html:12
 msgid "Search..."
@@ -98,4 +99,3 @@ msgstr "没有搜索到结果"
 #: mkdocs/themes/mkdocs/toc.html:3
 msgid "Table of Contents"
 msgstr "目录"
-

--- a/mkdocs/themes/readthedocs/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/zh_CN/LC_MESSAGES/messages.po
@@ -5,17 +5,19 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/"
+"issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
-"PO-Revision-Date: 2022-08-23 04:29+0800\n"
+"PO-Revision-Date: 2024-04-26 06:39+0800\n"
 "Last-Translator: xingkong0113 <dingpengyu06@gmail.com>\n"
-"Language: zh_CN\n"
 "Language-Team: zh_Hans_CN <dingpengyu06@gmail.com>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.14.0\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: mkdocs/themes/readthedocs/404.html:7
 msgid "Page not found"
@@ -74,11 +76,12 @@ msgstr "页脚导航"
 msgid ""
 "Built with %(mkdocs_link)s using a %(sphinx_link)s provided by "
 "%(rtd_link)s."
-msgstr "用%(mkdocs_link)s构建，使用%(rtd_link)s提供的%(sphinx_link)s。"
+msgstr ""
+"用%(mkdocs_link)s构建，使用%(rtd_link)s提供的%(sphinx_link)s。"
 
 #: mkdocs/themes/readthedocs/footer.html:25
 msgid "theme"
-msgstr ""
+msgstr "主题"
 
 #: mkdocs/themes/readthedocs/search.html:5
 msgid "Search Results"
@@ -108,4 +111,3 @@ msgstr "搜索文档"
 #: mkdocs/themes/readthedocs/versions.html:1
 msgid "Versions"
 msgstr "版本"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ format = [
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
-    "codespell",
+    "codespell==2.2.6",
 ]
 [tool.hatch.envs.lint.scripts]
 spelling = 'codespell mkdocs docs *.* -S LC_MESSAGES -S "*.min.js" -S "lunr*.js" -S fontawesome-webfont.svg -S tinyseg.js -S "*.map"'


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `0ac05da..8058b78`
**Files Changed:** 19 (8 programming files)
**Programming Ratio:** 42.1%

**Commits included:**
- Merge pull request #3787 from squidfunk/fix/prev-next-links-2
- Updated description of use_directory_urls (#3798)
- Fix prev/next keyboard navigation
- Docs: Dead links at types of GitHub Pages sites. (#3764)
- Fix Developer Guide -> User Guide in User Guide README (#3762)
- Merge pull request #3730 from squidfunk/fix/menu
- Update mkdocs/themes/mkdocs/js/base.js
- Merge pull request #3743 from mkdocs/pin-codespell
- Pin codespell dependancie
- Fix linter errors
... and 17 more commits